### PR TITLE
fix(ci): skip binary files in address/secret scanners

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -17,7 +17,7 @@ library(crew)
 
 tar_option_set(
   packages = c("dplyr", "arrow", "pointblank", "purrr"),
-  controller = crew_controller_local(workers = 2L),
+  controller = crew_controller_local(workers = 2L, seconds_wall = 3600),
   memory = "transient",
   garbage_collection = TRUE,
   format = "rds"

--- a/scripts/ci/check_addresses.py
+++ b/scripts/ci/check_addresses.py
@@ -60,8 +60,8 @@ SKIP_PATTERNS = [
     "pipeline-output/",
     "_extensions/",
     ".git/",
-    "data/price_history.csv",
-    "data/latest_prices.csv",
+    "data/price_history.parquet",
+    "data/nft_floor_history.parquet",
     "scripts/ci/check_addresses.py",  # this file, which mentions them
     "scripts/ci/check_secrets.py",     # this file, which mentions key patterns
     "scripts/ci/install-hooks.sh",     # example test address in help text
@@ -69,10 +69,25 @@ SKIP_PATTERNS = [
     "CHANGELOG.md",                    # may mention old patterns
 ]
 
+# Binary file extensions — random bytes can match base58/hex regexes.
+BINARY_EXTENSIONS = {".parquet", ".db", ".sqlite", ".png", ".jpg", ".jpeg",
+                     ".gif", ".pdf", ".zip", ".gz", ".tar", ".woff", ".woff2"}
+
 
 def should_skip(path):
     path_str = str(path)
     return any(pat in path_str for pat in SKIP_PATTERNS)
+
+
+def is_binary_file(path):
+    """Detect binary files via null-byte sniff of first 8KB."""
+    if Path(path).suffix.lower() in BINARY_EXTENSIONS:
+        return True
+    try:
+        with open(path, "rb") as fh:
+            return b"\x00" in fh.read(8192)
+    except (IsADirectoryError, FileNotFoundError, PermissionError):
+        return False
 
 
 def is_allowed(address):
@@ -130,6 +145,8 @@ def main():
         if should_skip(f):
             continue
         if not Path(f).exists():
+            continue
+        if is_binary_file(f):
             continue
 
         violations = scan_file(f)

--- a/scripts/ci/check_secrets.py
+++ b/scripts/ci/check_secrets.py
@@ -42,13 +42,17 @@ SKIP_PATTERNS = [
     "pipeline-output/",
     "_extensions/",
     ".git/",
-    "data/price_history.csv",
-    "data/latest_prices.csv",
+    "data/price_history.parquet",
+    "data/nft_floor_history.parquet",
     "scripts/ci/check_secrets.py",  # this file mentions the patterns as examples
     ".env.example",                  # template with empty values
     "CHANGELOG.md",                  # may mention past incidents
     "docs/PACKAGING_PLAN.md",        # example configs
 ]
+
+# Binary file extensions — random bytes can match hex/base58 regexes.
+BINARY_EXTENSIONS = {".parquet", ".db", ".sqlite", ".png", ".jpg", ".jpeg",
+                     ".gif", ".pdf", ".zip", ".gz", ".tar", ".woff", ".woff2"}
 
 # False-positive allowlist: placeholder/example strings
 ALLOWLIST = {
@@ -62,6 +66,17 @@ ALLOWLIST = {
 def should_skip(path):
     s = str(path)
     return any(p in s for p in SKIP_PATTERNS)
+
+
+def is_binary_file(path):
+    """Detect binary files via null-byte sniff of first 8KB."""
+    if Path(path).suffix.lower() in BINARY_EXTENSIONS:
+        return True
+    try:
+        with open(path, "rb") as fh:
+            return b"\x00" in fh.read(8192)
+    except (IsADirectoryError, FileNotFoundError, PermissionError):
+        return False
 
 
 def redact(secret):
@@ -109,6 +124,8 @@ def main():
     total = 0
     for f in files:
         if should_skip(f) or not Path(f).exists():
+            continue
+        if is_binary_file(f):
             continue
         violations = scan_file(f)
         if violations:

--- a/tests/test_ci_checks.py
+++ b/tests/test_ci_checks.py
@@ -134,6 +134,40 @@ def test_secrets_skip_env_example():
     assert rc == 0, out
 
 
+# ---- binary-file skip (regression: parquet false positive, run #92) ----
+
+def test_addresses_skip_binary_by_null_bytes():
+    """A binary file containing base58-shaped bytes must not trigger the scanner."""
+    fake_addr = b"So11111111111111111111111111111111111111113"
+    payload = b"PAR1\x00\x00" + fake_addr + b"\x00\x00\x00 some\x00bytes"
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+        f.write(payload)
+        f.flush()
+        rc, out, _ = run_check("scripts/ci/check_addresses.py", [f.name])
+    Path(f.name).unlink()
+    assert rc == 0, out
+
+def test_addresses_skip_binary_by_extension():
+    """A .parquet file must be skipped even if its bytes look like base58."""
+    fake_addr = b"So11111111111111111111111111111111111111113"
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        f.write(b"PAR1" + fake_addr + b"PAR1")  # no null bytes; extension catches it
+        f.flush()
+        rc, out, _ = run_check("scripts/ci/check_addresses.py", [f.name])
+    Path(f.name).unlink()
+    assert rc == 0, out
+
+def test_secrets_skip_binary_files():
+    """check_secrets must also skip binary files (elevenlabs 32-hex regex hits parquet bytes)."""
+    payload = b"PAR1\x00" + (b"abcdef0123456789" * 4) + b"\x00 binary"
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        f.write(payload)
+        f.flush()
+        rc, out, _ = run_check("scripts/ci/check_secrets.py", [f.name])
+    Path(f.name).unlink()
+    assert rc == 0, out
+
+
 if __name__ == "__main__":
     import pytest
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

- **`fix(ci)`** — scheduled-run workflow has failed since the CSV→parquet migration (commit `13afade`). `check_addresses.py` reads `data/*.parquet` as text and the Solana base58 regex `[1-9A-HJ-NP-Za-km-z]{32,44}` matches random byte sequences (`Fmmn...xyzz` at "line 112" of `nft_floor_history.parquet`, run #92). Adds binary-file detection (null-byte sniff + `.parquet/.db/.sqlite/...` extension allowlist) to both `check_addresses.py` and `check_secrets.py`. Swaps stale `data/*.csv` entries in `SKIP_PATTERNS` for current `data/*.parquet` paths as defense-in-depth.
- **`fix(crew)`** — adds `seconds_wall=3600` to crew controller to prevent orphaned workers (carried over from prior commit on this branch).

## Diagnosis (from run #92 log)

```
data/nft_floor_history.parquet:
  line 112: solana address Fmmn...xyzz (not in allowlist)
============================================================
BLOCKED: 1 wallet address(es) found in staged files.
```

`check_secrets.py` has the same latent bug (its `[a-f0-9]{32}` elevenlabs pattern can hit parquet bytes) — fixed at the same time.

## Test plan

- [x] Reproduced the failure locally against `data/nft_floor_history.parquet`
- [x] Verified fix: full `git ls-files` scan exits 0 (`OK (35 file(s) scanned)`)
- [x] Regression: a text file containing a non-allowlisted base58 address is still blocked (exit 1)
- [x] Added 3 pytest cases covering binary-skip: null-byte detection, `.parquet` extension, secrets-on-binary
- [x] Full test suite: `14 passed in 0.52s`
- [ ] CI: this PR's `scheduled-run.yml` push trigger will exercise the fix end-to-end
